### PR TITLE
Simple Travis CI config. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - "3.4"
+
+# Setup anaconda
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
+  - sudo rm -rf /dev/shm
+  - sudo ln -s /run/shm /dev/shm
+
+# Install packages
+install:
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose dateutil pandas statsmodels
+
+# Run test
+script: nosetests -v pbe/


### PR DESCRIPTION
Using Miniconda as Travis cannot install numpy and scipy with pip.
This runs the tests in the `pbe` directory with `nose`.
On my fork the tests currently pass.

To make this work you need to do two things:
1. Turn on the Travis webhook from the repository settings on GitHub
2. Log into travis, sync with your GitHub account and turn travis on for the `pyfd` repo
